### PR TITLE
Remove installation section from `README.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+2
+
+* Remove installation section from `README.md`
+
 ## 0.1.1+1
 
 * Format code for more pub points.

--- a/README.md
+++ b/README.md
@@ -14,15 +14,6 @@ This is a fork from [flutter-emoji](https://pub.dev/packages/flutter_emoji), whi
 
 `dart-emoji` is even used in production for our app Gatch. You can get Gatch for [iOS](https://gatch.fun/ios) and [Android](https://gatch.fun/android).
 
-## Installation
-
-Add this into `pubspec.yaml`
-
-```
-dependencies:
-  dart_emoji: ^0.1.0
-```
-
 ## API Usage
 
 First, import the package:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_emoji
 description: "A light-weight Emoji 📦 for Dart & Flutter with all up-to-date emojis written in pure Dart 😄 . Made from 💯% ☕ with ❤️!"
-version: 0.1.1+1
+version: 0.1.1+2
 homepage: "https://github.com/GatchHQ/dart-emoji"
 
 environment:


### PR DESCRIPTION
I removed this section from the `README.md`, because every package has an installation tab provided by pub.dev, and it's easy to forget to update this section.