### PR TITLE
Fix unnecessary type check in `dart_emoji_test.dart`

### DIFF
--- a/test/dart_emoji_test.dart
+++ b/test/dart_emoji_test.dart
@@ -119,8 +119,6 @@ void main() {
   test('emoji info', () {
     final heart = emojiParser.info('heart');
 
-    expect(heart is Emoji, true);
-
     expect(heart.name, 'heart');
     expect(heart.full, ':heart:');
     expect(heart.code, '❤️');


### PR DESCRIPTION
Analyzer warning was introduced with the new Dart version.

Fixes:
* https://github.com/GatchHQ/dart-emoji/runs/4565113567?check_suite_focus=true