### PR TITLE
Add `build` folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ util/
 # Packages should not commit the "pubspec.lock" file. See
 # https://stackoverflow.com/a/16136740/8358501
 pubspec.lock
+
+# Code Coverage
+coverage/
+build/


### PR DESCRIPTION
When generating a coverage report, a `build` folder is created. This folder should not be tracked in git. Therefore, I added the `build` folder to the `.gitignore` file.